### PR TITLE
Uniformbzmesh

### DIFF
--- a/src/AbstractMeshes.jl
+++ b/src/AbstractMeshes.jl
@@ -1,0 +1,37 @@
+module AbstractMeshes
+
+# define interface of AbstractMesh
+
+using ..StaticArrays
+
+export AbstractMesh, locate, volume
+
+# the return value of AbstractMesh should be a SVector{T,DIM}
+abstract type AbstractMesh{T,DIM} <: AbstractArray{SVector{T,DIM},DIM} end
+
+Base.IteratorSize(::Type{AbstractMesh{T,DIM}}) where {T,DIM} = Base.HasLength()
+Base.IteratorEltype(::Type{AbstractMesh{T,DIM}}) where {T,DIM} = Base.HasEltype()
+Base.eltype(::Type{AbstractMesh{T,DIM}}) where {T,DIM} = eltype(T)
+
+# these iterators relies on the interfaces to be implemented below
+# and might be implemented in other ways
+Base.firstindex(mesh::AbstractMesh) = 1
+Base.lastindex(mesh::AbstractMesh) = length(mesh)
+Base.iterate(mesh::AbstractMesh) = (mesh[1], 1)
+Base.iterate(mesh::AbstractMesh, state) = (state >= length(mesh)) ? nothing : (mesh[state+1], state + 1)
+
+# below are interfaces that should be implemented by concrete types
+Base.length(mesh::AbstractMesh) = error("not implemented!")
+Base.size(mesh::AbstractMesh) = error("not implemented!")
+Base.size(mesh::AbstractMesh, I) = error("not implemented!")
+
+Base.show(io::IO, mesh::AbstractMesh) = error("not implemented!")
+
+Base.getindex(mesh::AbstractMesh, inds...) = error("not implemented!")
+Base.getindex(mesh::AbstractMesh, I) = error("not implemented!")
+
+locate(mesh::AbstractMesh, x) = error("not implemented!")
+volume(mesh::AbstractMesh) = error("not implemented!")
+volume(mesh::AbstractMesh, I) = error("not implemented!")
+
+end

--- a/src/AbstractMeshes.jl
+++ b/src/AbstractMeshes.jl
@@ -34,4 +34,22 @@ locate(mesh::AbstractMesh, x) = error("not implemented!")
 volume(mesh::AbstractMesh) = error("not implemented!")
 volume(mesh::AbstractMesh, I) = error("not implemented!")
 
+# tools useful for AbstractMesh
+@generated function _inds2ind(size::NTuple{DIM,Int}, I) where {DIM}
+    ex = :(I[DIM] - 1)
+    for i = (DIM-1):-1:1
+        ex = :(I[$i] - 1 + size[$i] * $ex)
+    end
+    return :($ex + 1)
+end
+
+@generated function _ind2inds(size::NTuple{DIM,Int}, I::Int) where {DIM}
+    inds, quotient = :((I - 1) % size[1] + 1), :((I - 1) ÷ size[1])
+    for i = 2:DIM-1
+        inds, quotient = :($inds..., $quotient % size[$i] + 1), :($quotient ÷ size[$i])
+    end
+    inds = :($inds..., $quotient + 1)
+    return :(SVector{DIM,Int}($inds))
+end
+
 end

--- a/src/BZMeshes.jl
+++ b/src/BZMeshes.jl
@@ -1,5 +1,123 @@
 module BZMeshes
 
+using ..StaticArrays
+using ..LinearAlgebra
 
+using ..AbstractMeshes
+using ..AbstractMeshes: _inds2ind, _ind2inds
+using ..Model
+using ..BaseMesh
+using ..BaseMesh: _indfloor
+
+export UniformBZMesh
+
+"""
+    struct UniformBZMesh{T, DIM} <: AbstractMesh{T, DIM}
+
+Uniformly distributed Brillouin zone mesh. Defined as a uniform mesh on 1st Brillouin zone
+with Brillouin zone information stored in mesh.br::Brillouin. 
+
+# Parameters:
+- `T`: type of data
+- `DIM`: dimension of the Brillouin zone
+
+# Members:
+- `br`: Brillouin zone information including lattice info, atom pos and allowed G vectors
+- `origin`: origin of the uniform mesh, related to convention of 1st Brillouin zone. Commonly set to either (0,0,0) or such that (0,0,0) is at the center
+- `size`: size of the uniform mesh. For Monkhorst-Pack mesh require even number.
+- `shift`: k-shift of each mesh point. Take all zero for Gamma-centered and all 1//2 for M-P mesh
+"""
+struct UniformBZMesh{T,DIM} <: AbstractMesh{T,DIM}
+    br::Brillouin{T,DIM}
+    mesh::UMesh{T,DIM}
+end
+
+# default shift is 1/2, result in Monkhorst-Pack mesh
+# with shift = 0, result in Gamma-centered
+# can also customize with shift::SVector by calling default constructor
+# \Gamma=(0,0,0) is at center by default, can be set at corner by setting origin to it
+"""
+    function UniformBZMesh(; br::Brillouin, origin, size, shift)
+
+customized constructor for UniformBZMesh. The parameters origin and shift is provided to customize
+the mesh as Gamma-centered or M-P mesh. 
+
+# Parameters:
+- `br`: Brillouin zone info
+- `origin`: a number indicating shift of origin. 
+    the actuall origin becomes origin*(b1+b2+b3)
+    default value origin=-0.5 takes (0,0,0) to center of 1st BZ, origin=0 makes mesh[1,1,1]=(0,0,0)+shift
+- `size`: size of the mesh
+- `shift`: additional k-shift for mesh points. 
+    actuall shift is shift*(b1/N1+b2/N2+b3/N3)
+    for even N, shift=0.5 avoids high symmetry points while preserve symmetry.
+"""
+UniformBZMesh(;
+    br::Brillouin{T,DIM},
+    origin::Real=-0.5,
+    size,
+    shift::Real=1 // 2) where {T,DIM} = UniformBZMesh{T,DIM}(
+    br,
+    UMesh(br=br, origin=origin, size=size, shift=shift)
+)
+
+Base.length(mesh::UniformBZMesh) = length(mesh.mesh)
+Base.size(mesh::UniformBZMesh) = size(mesh.mesh)
+Base.size(mesh::UniformBZMesh, I) = size(mesh.mesh)
+
+function Base.show(io::IO, mesh::UniformBZMesh)
+    println("UniformBZMesh with $(length(mesh)) mesh points")
+end
+
+function Base.getindex(mesh::UniformBZMesh{T,DIM}, inds...) where {T,DIM}
+    return Base.getindex(mesh.mesh, inds...)
+end
+
+function Base.getindex(mesh::UniformBZMesh, I::Int)
+    return Base.getindex(mesh, _ind2inds(size(mesh), I)...)
+end
+
+"""
+    function AbstractMeshes.locate(mesh::UniformBZMesh{T,DIM}, x) where {T,DIM}
+
+locate mesh point in mesh that is nearest to x. Useful for Monte-Carlo algorithm.
+Could also be used for zeroth order interpolation.
+
+# Parameters
+- `mesh`: aimed mesh
+- `x`: cartesian pos to locate
+"""
+function AbstractMeshes.locate(mesh::UniformBZMesh{T,DIM}, x) where {T,DIM}
+    # find index of nearest grid point to the point
+    return AbstractMeshes.locate(mesh.mesh, x)
+end
+
+"""
+    function AbstractMeshes.volume(mesh::UniformBZMesh, i)
+
+volume represented by mesh point i. When i is omitted return volume of the whole mesh. 
+For M-P mesh it's always volume(mesh)/length(mesh), but for others things are more complecated.
+Here we assume periodic boundary condition so for all case it's the same.
+
+# Parameters:
+- `mesh`: mesh
+- `i`: index of mesh point, if ommited return volume of whole mesh
+"""
+AbstractMeshes.volume(mesh::UniformBZMesh) = mesh.br.recip_cell_volume
+AbstractMeshes.volume(mesh::UniformBZMesh, i) = mesh.br.recip_cell_volume / length(mesh)
+
+# function AbstractMeshes.volume(mesh::UniformBZMesh{T,DIM}, i) where {T,DIM}
+#     inds = _ind2inds(mesh.size, i)
+#     cellarea = T(1.0)
+#     for j in 1:DIM
+#         if inds[j] == 1
+#             cellarea *= T(0.5) + mesh.shift[j]
+#         elseif inds[j] == mesh.size[j]
+#             cellarea *= T(1.5) - mesh.shift[j]
+#         end
+#         # else cellarea *= 1.0 so nothing
+#     end
+#     return cellarea / length(mesh) * volume(mesh)
+# end
 
 end

--- a/src/BZMeshes.jl
+++ b/src/BZMeshes.jl
@@ -54,7 +54,7 @@ the mesh as Gamma-centered or M-P mesh.
 """
 UniformBZMesh(;
     br::Brillouin{T,DIM},
-    origin::Real=-0.5,
+    origin::Real=-1 // 2,
     size,
     shift::Real=1 // 2) where {T,DIM} = UniformBZMesh{T,DIM}(
     br,

--- a/src/BZMeshes.jl
+++ b/src/BZMeshes.jl
@@ -1,0 +1,5 @@
+module BZMeshes
+
+
+
+end

--- a/src/Basemesh.jl
+++ b/src/Basemesh.jl
@@ -9,6 +9,11 @@ export UniformMesh, BaryChebMesh, CenteredMesh, EdgedMesh, AbstractMesh, locate,
 
 abstract type AbstractMesh{T,DIM} <: AbstractArray{SVector{T,DIM},DIM} end
 
+Base.IteratorSize(::Type{AbstractMesh{T,DIM}}) where {T,DIM} = Base.HasLength()
+Base.IteratorEltype(::Type{AbstractMesh{T,DIM}}) where {T,DIM} = Base.HasEltype()
+Base.eltype(::Type{AbstractMesh{T,DIM}}) where {T,DIM} = eltype(T)
+
+
 """
 Compute the inverse of the lattice. Require lattice to be square matrix
 """

--- a/src/Basemesh.jl
+++ b/src/Basemesh.jl
@@ -127,6 +127,22 @@ end
 # with shift = 0, result in Gamma-centered
 # can also customize with shift::SVector by calling default constructor
 # \Gamma=(0,0,0) is at center by default, can be set at corner by setting origin to it
+"""
+    function UniformBZMesh(; br::Brillouin, origin, size, shift)
+
+customized constructor for UniformBZMesh. The parameters origin and shift is provided to customize
+the mesh as Gamma-centered or M-P mesh. 
+
+# Parameters:
+- `br`: Brillouin zone info
+- `origin`: a number indicating shift of origin. 
+    the actuall origin becomes origin*(b1+b2+b3)
+    default value origin=-0.5 takes (0,0,0) to center of 1st BZ, origin=0 makes mesh[1,1,1]=(0,0,0)+shift
+- `size`: size of the mesh
+- `shift`: additional k-shift for mesh points. 
+    actuall shift is shift*(b1/N1+b2/N2+b3/N3)
+    for even N, shift=0.5 avoids high symmetry points while preserve symmetry.
+"""
 UniformBZMesh(; br::Brillouin{T,DIM}, origin::Real=-0.5, size, shift::Number=1 // 2) where {T,DIM} = UniformBZMesh{T,DIM}(br, SVector{DIM,T}(br.recip_lattice * ones(T, DIM) .* origin), size, SVector{DIM,Rational}(shift .* ones(Int, DIM)))
 
 Base.length(mesh::UniformBZMesh) = prod(mesh.size)
@@ -170,6 +186,7 @@ Base.iterate(mesh::UniformBZMesh) = (mesh[1], 1)
 Base.iterate(mesh::UniformBZMesh, state) = (state >= length(mesh)) ? nothing : (mesh[state+1], state + 1)
 
 function _indfloor(x, N; edgeshift=1)
+
     # edgeshift = 1 by default in floor function so that end point return N-1
     # edgeshift = 0 in locate function
     if x < 1

--- a/src/Basemesh.jl
+++ b/src/Basemesh.jl
@@ -9,10 +9,19 @@ export UniformMesh, BaryChebMesh, CenteredMesh, EdgedMesh, AbstractMesh, locate,
 
 abstract type AbstractMesh{T,DIM} <: AbstractArray{SVector{T,DIM},DIM} end
 
-function _compute_inverse_lattice(lattice)
+"""
+Compute the inverse of the lattice. Require lattice to be square matrix
+"""
+function _compute_inverse_lattice(lattice::Matrix{T}) where {T}
+    @assert size(lattice)[1] == size(lattice)[2]
     return inv(lattice)
 end
 
+"""
+Compute the reciprocal lattice.
+We use the convention that the reciprocal lattice is the set of G vectors such
+that G ⋅ R ∈ 2π ℤ for all R in the lattice.
+"""
 function _compute_recip_lattice(lattice::Matrix{T}) where {T}
     return 2T(π) * _compute_inverse_lattice(lattice)
 end
@@ -37,17 +46,24 @@ volume of unit cell and reciprocal unit cell; G vectors for extended Brillouin z
 - `G_vector`: a list of G vectors in extended Brillouin zone
 """
 struct Brillouin{T,DIM}
+    # Lattice and reciprocal lattice vectors in columns
     lattice::Matrix{T}
     recip_lattice::Matrix{T}
+    # Useful for conversions between cartesian and reduced coordinates
     inv_lattice::Matrix{T}
     inv_recip_lattice::Matrix{T}
+
     unit_cell_volume::T
     recip_cell_volume::T
+
+    # collection of all allowed G vectors
     G_vector::Vector{SVector{DIM,Int}}
 end
 
 
-function Brillouin(; lattice::Matrix{T}, G_vector=nothing) where {T}
+function Brillouin(;
+    lattice::Matrix{T},
+    G_vector=nothing) where {T}
     DIM = size(lattice, 1)
     recip_lattice = _compute_recip_lattice(lattice)
     inv_lattice = _compute_inverse_lattice(lattice)

--- a/src/Basemesh.jl
+++ b/src/Basemesh.jl
@@ -4,6 +4,7 @@ using ..StaticArrays
 using ..LinearAlgebra
 
 using ..BaryCheb
+using ..Model
 
 export UniformMesh, BaryChebMesh, CenteredMesh, EdgedMesh, AbstractMesh, locate, volume
 
@@ -12,103 +13,6 @@ abstract type AbstractMesh{T,DIM} <: AbstractArray{SVector{T,DIM},DIM} end
 Base.IteratorSize(::Type{AbstractMesh{T,DIM}}) where {T,DIM} = Base.HasLength()
 Base.IteratorEltype(::Type{AbstractMesh{T,DIM}}) where {T,DIM} = Base.HasEltype()
 Base.eltype(::Type{AbstractMesh{T,DIM}}) where {T,DIM} = eltype(T)
-
-
-"""
-Compute the inverse of the lattice. Require lattice to be square matrix
-"""
-function _compute_inverse_lattice(lattice::Matrix{T}) where {T}
-    @assert size(lattice, 2) == size(lattice, 2)
-    return inv(lattice)
-end
-
-"""
-Compute the reciprocal lattice.
-We use the convention that the reciprocal lattice is the set of G vectors such
-that G ⋅ R ∈ 2π ℤ for all R in the lattice.
-"""
-function _compute_recip_lattice(lattice::Matrix{T}) where {T}
-    return 2T(π) * _compute_inverse_lattice(lattice)
-end
-
-"""
-    struct Brillouin{T, DIM}
-
-Container storing information of Brillouin zone. Including lattice vector, reciprocal lattice vector and their inverse;
-volume of unit cell and reciprocal unit cell; G vectors for extended Brillouin zone.
-
-# Parameters:
-- `T`: type of data
-- `DIM`: dimension of the Brillouin zone
-
-# Members:
-- `lattice`: lattice vector
-- `recip_lattice`: reciprocal lattice vector
-- `inv_lattice`: inverse of lattice vector
-- `inv_recip_lattice`: inverse of reciprocal lattice vector
-- `unit_cell_volume`: volume of lattice unit cell
-- `recip_cell_volume`: volume of reciprocal lattice unit cell
-- `G_vector`: a list of G vectors in extended Brillouin zone
-"""
-struct Brillouin{T,DIM}
-    # Lattice and reciprocal lattice vectors in columns
-    lattice::Matrix{T}
-    recip_lattice::Matrix{T}
-    # Useful for conversions between cartesian and reduced coordinates
-    inv_lattice::Matrix{T}
-    inv_recip_lattice::Matrix{T}
-
-    unit_cell_volume::T
-    recip_cell_volume::T
-
-    # Particle types (elements) and particle positions and in fractional coordinates.
-    # Possibly empty. It's up to the `term_types` to make use of this (or not).
-    # `atom_groups` contains the groups of indices into atoms and positions, which
-    # point to identical atoms. It is computed automatically on Model construction and may
-    # be used to optimise the term instantiation.
-    atoms::Vector{Int}
-    positions::Vector{SVector{DIM,T}}  # positions[i] is the location of atoms[i] in fract. coords
-    atom_groups::Vector{Vector{Int}}  # atoms[i] == atoms[j] for all i, j in atom_group[α]
-
-
-    # collection of all allowed G vectors
-    G_vector::Vector{SVector{DIM,Int}}
-end
-
-
-function Brillouin(;
-    lattice::Matrix{T},
-    atoms::Vector{Int}=Vector{Int}([]),
-    positions=nothing,
-    G_vector=nothing) where {T}
-
-    DIM = size(lattice, 1)
-
-    if isnothing(positions)
-        positions = Vector{SVector{DIM,T}}[]
-    end
-
-    # Atoms and terms
-    if length(atoms) != length(positions)
-        error("Length of atoms and positions vectors need to agree.")
-    end
-    atom_groups = [findall(Ref(pot) .== atoms) for pot in Set(atoms)]
-
-    # Lattice Vectors
-    @assert size(lattice, 1) == size(lattice, 2) "Lattice vector should be given in square matrix!"
-    recip_lattice = _compute_recip_lattice(lattice)
-    inv_lattice = _compute_inverse_lattice(lattice)
-    inv_recip_lattice = _compute_inverse_lattice(recip_lattice)
-    unit_cell_volume = abs(det(lattice))
-    recip_cell_volume = abs(det(recip_lattice))
-
-    # G vector default (0,0,0)
-    if isnothing(G_vector)
-        G_vector = [SVector{DIM,Int}(zeros(DIM)),]
-    end
-
-    return Brillouin{T,DIM}(lattice, recip_lattice, inv_lattice, inv_recip_lattice, unit_cell_volume, recip_cell_volume, atoms, positions, atom_groups, G_vector)
-end
 
 """
     struct UniformBZMesh{T, DIM} <: AbstractMesh{T, DIM}

--- a/src/BrillouinZoneMeshes.jl
+++ b/src/BrillouinZoneMeshes.jl
@@ -18,10 +18,15 @@ include("Model.jl")
 using .Model
 export Brillouin
 
-include("Basemesh.jl")
+include("BaseMesh.jl")
 using .BaseMesh
 export BaseMesh
 export UniformMesh, BaryChebMesh, CenteredMesh, EdgedMesh, AbstractMesh# , locate, volume
+
+include("BZMeshes.jl")
+using .BZMeshes
+export BZMeshes
+export UniformBZMesh
 
 include("symmetry/UniformKMeshSym.jl")
 

--- a/src/BrillouinZoneMeshes.jl
+++ b/src/BrillouinZoneMeshes.jl
@@ -10,6 +10,10 @@ using CompositeGrids
 BaryCheb = CompositeGrids.BaryChebTools
 # export BaryCheb
 
+include("AbstractMeshes.jl")
+using .AbstractMeshes
+export AbstractMeshes, AbstractMesh
+
 include("Model.jl")
 using .Model
 export Brillouin

--- a/src/BrillouinZoneMeshes.jl
+++ b/src/BrillouinZoneMeshes.jl
@@ -10,6 +10,10 @@ using CompositeGrids
 BaryCheb = CompositeGrids.BaryChebTools
 # export BaryCheb
 
+include("Model.jl")
+using .Model
+export Brillouin
+
 include("Basemesh.jl")
 using .BaseMesh
 export BaseMesh

--- a/src/MeshMaps.jl
+++ b/src/MeshMaps.jl
@@ -1,6 +1,8 @@
 module MeshMaps
 # symmetry reduce map for meshes
 
+using ..AbstractMeshes
+using ..Model
 using ..TreeMeshes
 using ..BaseMesh
 """

--- a/src/Model.jl
+++ b/src/Model.jl
@@ -1,0 +1,104 @@
+module Model
+
+using ..StaticArrays
+using ..LinearAlgebra
+
+export Brillouin
+
+"""
+Compute the inverse of the lattice. Require lattice to be square matrix
+"""
+function _compute_inverse_lattice(lattice::Matrix{T}) where {T}
+    @assert size(lattice, 2) == size(lattice, 2)
+    return inv(lattice)
+end
+
+"""
+Compute the reciprocal lattice.
+We use the convention that the reciprocal lattice is the set of G vectors such
+that G ⋅ R ∈ 2π ℤ for all R in the lattice.
+"""
+function _compute_recip_lattice(lattice::Matrix{T}) where {T}
+    return 2T(π) * _compute_inverse_lattice(lattice)
+end
+
+"""
+    struct Brillouin{T, DIM}
+
+Container storing information of Brillouin zone. Including lattice vector, reciprocal lattice vector and their inverse;
+volume of unit cell and reciprocal unit cell; G vectors for extended Brillouin zone.
+
+# Parameters:
+- `T`: type of data
+- `DIM`: dimension of the Brillouin zone
+
+# Members:
+- `lattice`: lattice vector
+- `recip_lattice`: reciprocal lattice vector
+- `inv_lattice`: inverse of lattice vector
+- `inv_recip_lattice`: inverse of reciprocal lattice vector
+- `unit_cell_volume`: volume of lattice unit cell
+- `recip_cell_volume`: volume of reciprocal lattice unit cell
+- `G_vector`: a list of G vectors in extended Brillouin zone
+"""
+struct Brillouin{T,DIM}
+    # Lattice and reciprocal lattice vectors in columns
+    lattice::Matrix{T}
+    recip_lattice::Matrix{T}
+    # Useful for conversions between cartesian and reduced coordinates
+    inv_lattice::Matrix{T}
+    inv_recip_lattice::Matrix{T}
+
+    unit_cell_volume::T
+    recip_cell_volume::T
+
+    # Particle types (elements) and particle positions and in fractional coordinates.
+    # Possibly empty. It's up to the `term_types` to make use of this (or not).
+    # `atom_groups` contains the groups of indices into atoms and positions, which
+    # point to identical atoms. It is computed automatically on Model construction and may
+    # be used to optimise the term instantiation.
+    atoms::Vector{Int}
+    positions::Vector{SVector{DIM,T}}  # positions[i] is the location of atoms[i] in fract. coords
+    atom_groups::Vector{Vector{Int}}  # atoms[i] == atoms[j] for all i, j in atom_group[α]
+
+
+    # collection of all allowed G vectors
+    G_vector::Vector{SVector{DIM,Int}}
+end
+
+
+function Brillouin(;
+    lattice::Matrix{T},
+    atoms::Vector{Int}=Vector{Int}([]),
+    positions=nothing,
+    G_vector=nothing) where {T}
+
+    DIM = size(lattice, 1)
+
+    if isnothing(positions)
+        positions = Vector{SVector{DIM,T}}[]
+    end
+
+    # Atoms and terms
+    if length(atoms) != length(positions)
+        error("Length of atoms and positions vectors need to agree.")
+    end
+    atom_groups = [findall(Ref(pot) .== atoms) for pot in Set(atoms)]
+
+    # Lattice Vectors
+    @assert size(lattice, 1) == size(lattice, 2) "Lattice vector should be given in square matrix!"
+    recip_lattice = _compute_recip_lattice(lattice)
+    inv_lattice = _compute_inverse_lattice(lattice)
+    inv_recip_lattice = _compute_inverse_lattice(recip_lattice)
+    unit_cell_volume = abs(det(lattice))
+    recip_cell_volume = abs(det(recip_lattice))
+
+    # G vector default (0,0,0)
+    if isnothing(G_vector)
+        G_vector = [SVector{DIM,Int}(zeros(DIM)),]
+    end
+
+    return Brillouin{T,DIM}(lattice, recip_lattice, inv_lattice, inv_recip_lattice, unit_cell_volume, recip_cell_volume, atoms, positions, atom_groups, G_vector)
+end
+
+end

--- a/src/PolarMeshes.jl
+++ b/src/PolarMeshes.jl
@@ -1,5 +1,7 @@
 module PolarMeshes
 
+using ..AbstractMeshes
+using ..Model
 using ..StaticArrays
 using ..CompositeGrids
 using ..BaseMesh

--- a/src/TreeMeshes.jl
+++ b/src/TreeMeshes.jl
@@ -1,5 +1,6 @@
 module TreeMeshes
 
+using ..AbstractMeshes
 using ..AbstractTrees
 using ..StaticArrays
 using ..BaseMesh

--- a/src/symmetry/elements.jl
+++ b/src/symmetry/elements.jl
@@ -1,0 +1,188 @@
+import PeriodicTable
+using AtomsBase
+# Alias to avoid similarity of elements and Element in DFTK module namespace
+periodic_table = PeriodicTable.elements
+
+# Data structure for chemical element and the potential model via which
+# they interact with electrons. A compensating charge background is
+# always assumed. It is assumed that each implementing struct
+# defines at least the functions `local_potential_fourier` and `local_potential_real`.
+# Very likely `charge_nuclear` and `charge_ionic` need to be defined as well.
+abstract type Element end
+
+"""Return the total nuclear charge of an atom type"""
+charge_nuclear(::Element) = 0
+
+"""Chemical symbol corresponding to an element"""
+AtomsBase.atomic_symbol(::Element) = :X
+# The preceeding functions are fallback implementations that should be altered as needed.
+
+"""Return the total ionic charge of an atom type (nuclear charge - core electrons)"""
+charge_ionic(el::Element) = charge_nuclear(el)
+
+"""Return the number of valence electrons"""
+n_elec_valence(el::Element) = charge_ionic(el)
+
+"""Return the number of core electrons"""
+n_elec_core(el::Element) = charge_nuclear(el) - charge_ionic(el)
+
+"""Radial local potential, in Fourier space: V(q) = int_{R^3} V(x) e^{-iqx} dx."""
+function local_potential_fourier(el::Element, q::AbstractVector)
+    local_potential_fourier(el, norm(q))
+end
+
+"""Radial local potential, in real space."""
+function local_potential_real(el::Element, q::AbstractVector)
+    local_potential_real(el, norm(q))
+end
+
+# Fallback print function:
+Base.show(io::IO, el::Element) = print(io, "$(typeof(el))($(atomic_symbol(el)))")
+
+
+struct ElementCoulomb <: Element
+    Z::Int  # Nuclear charge
+    symbol  # Element symbol
+end
+charge_ionic(el::ElementCoulomb)   = el.Z
+charge_nuclear(el::ElementCoulomb) = el.Z
+AtomsBase.atomic_symbol(el::ElementCoulomb) = el.symbol
+
+"""
+Element interacting with electrons via a bare Coulomb potential
+(for all-electron calculations)
+`key` may be an element symbol (like `:Si`), an atomic number (e.g. `14`)
+or an element name (e.g. `"silicon"`)
+"""
+ElementCoulomb(key) = ElementCoulomb(periodic_table[key].number, Symbol(periodic_table[key].symbol))
+
+
+function local_potential_fourier(el::ElementCoulomb, q::T) where {T <: Real}
+    q == 0 && return zero(T)  # Compensating charge background
+    # General atom => Use default Coulomb potential
+    # We use int_{R^3} -Z/r e^{-i q⋅x} = 4π / |q|^2
+    return -4T(π) * el.Z / q^2
+end
+
+local_potential_real(el::ElementCoulomb, r::Real) = -el.Z / r
+
+
+struct ElementPsp <: Element
+    Z::Int  # Nuclear charge
+    symbol  # Element symbol
+    psp     # Pseudopotential data structure
+end
+function Base.show(io::IO, el::ElementPsp)
+    pspid = isempty(el.psp.identifier) ? "custom" : el.psp.identifier
+    print(io, "ElementPsp($(el.symbol), psp=\"$pspid\")")
+end
+
+"""
+Element interacting with electrons via a pseudopotential model.
+`key` may be an element symbol (like `:Si`), an atomic number (e.g. `14`)
+or an element name (e.g. `"silicon"`)
+"""
+function ElementPsp(key; psp)
+    ElementPsp(periodic_table[key].number, Symbol(periodic_table[key].symbol), psp)
+end
+charge_ionic(el::ElementPsp)   = charge_ionic(el.psp)
+charge_nuclear(el::ElementPsp) = el.Z
+AtomsBase.atomic_symbol(el::ElementPsp) = el.symbol
+
+function local_potential_fourier(el::ElementPsp, q::T) where {T <: Real}
+    q == 0 && return zero(T)  # Compensating charge background
+    eval_psp_local_fourier(el.psp, q)
+end
+
+function local_potential_real(el::ElementPsp, r::Real)
+    # Use local part of pseudopotential defined in Element object
+    return eval_psp_local_real(el.psp, r)
+end
+
+
+struct ElementCohenBergstresser <: Element
+    Z::Int  # Nuclear charge
+    symbol  # Element symbol
+    V_sym   # Map |G|^2 (in units of (2π / lattice_constant)^2) to form factors
+    lattice_constant  # Lattice constant (in Bohr) which is assumed
+end
+charge_ionic(el::ElementCohenBergstresser)   = 4
+charge_nuclear(el::ElementCohenBergstresser) = el.Z
+AtomsBase.atomic_symbol(el::ElementCohenBergstresser) = el.symbol
+
+"""
+Element where the interaction with electrons is modelled
+as in [CohenBergstresser1966](https://doi.org/10.1103/PhysRev.141.789).
+Only the homonuclear lattices of the diamond structure
+are implemented (i.e. Si, Ge, Sn).
+
+`key` may be an element symbol (like `:Si`), an atomic number (e.g. `14`)
+or an element name (e.g. `"silicon"`)
+"""
+function ElementCohenBergstresser(key; lattice_constant=nothing)
+    # Form factors from Cohen-Bergstresser paper Table 2, converted to Bohr
+    # Lattice constants from Table 1, converted to Bohr
+    data = Dict(:Si => (form_factors=Dict( 3 => -0.21u"Ry",
+                                           8 =>  0.04u"Ry",
+                                          11 =>  0.08u"Ry"),
+                        lattice_constant=5.43u"Å"),
+                :Ge => (form_factors=Dict( 3 => -0.23u"Ry",
+                                           8 =>  0.01u"Ry",
+                                          11 =>  0.06u"Ry"),
+                        lattice_constant=5.66u"Å"),
+                :Sn => (form_factors=Dict( 3 => -0.20u"Ry",
+                                           8 =>  0.00u"Ry",
+                                          11 =>  0.04u"Ry"),
+                        lattice_constant=6.49u"Å"),
+            )
+
+    symbol = Symbol(periodic_table[key].symbol)
+    if !(symbol in keys(data))
+        error("Cohen-Bergstresser potential not implemented for element $symbol.")
+    end
+    isnothing(lattice_constant) && (lattice_constant = data[symbol].lattice_constant)
+    lattice_constant = austrip(lattice_constant)
+
+    # Unit-cell volume of the primitive lattice (used in DFTK):
+    unit_cell_volume = det(lattice_constant / 2 .* [[0 1 1]; [1 0 1]; [1 1 0]])
+
+    # The form factors in the Cohen-Bergstresser paper Table 2 are
+    # with respect to normalized planewaves (i.e. not plain Fourier coefficients)
+    # and are already symmetrized into a sin-cos basis (see derivation p. 141)
+    # => Scale by Ω / 2 to get them into the DFTK convention
+    V_sym = Dict(key => austrip(value) * unit_cell_volume / 2
+                 for (key, value) in pairs(data[symbol].form_factors))
+
+    ElementCohenBergstresser(periodic_table[key].number, symbol, V_sym, lattice_constant)
+end
+
+function local_potential_fourier(el::ElementCohenBergstresser, q::T) where {T <: Real}
+    q == 0 && return zero(T)  # Compensating charge background
+
+    # Get |q|^2 in units of (2π / lattice_constant)^2
+    qsq_pi = Int(round(q^2 / (2π / el.lattice_constant)^2, digits=2))
+    T(get(el.V_sym, qsq_pi, 0.0))
+end
+
+
+struct ElementGaussian <: Element
+    α                               # Prefactor
+    L                               # Width of the Gaussian nucleus
+    symbol::Union{Nothing, Symbol}  # Element symbol
+end
+AtomsBase.atomic_symbol(el::ElementGaussian) = el.symbol
+
+"""
+Element interacting with electrons via a Gaussian potential.
+Symbol is non-mandatory.
+"""
+function ElementGaussian(α, L; symbol=nothing)
+    ElementGaussian(α, L, symbol)
+end
+function local_potential_real(el::ElementGaussian, r)
+    -el.α / (√(2π) * el.L) * exp(- (r / el.L)^2 / 2)
+end
+function local_potential_fourier(el::ElementGaussian, q::Real)
+    # = ∫_ℝ³ V(x) exp(-ix⋅q) dx
+    -el.α * exp(- (q * el.L)^2 / 2)
+end

--- a/test/BaseMesh.jl
+++ b/test/BaseMesh.jl
@@ -68,6 +68,10 @@
             end
             @test vol ≈ BaseMesh.volume(bzmesh)
         end
+
+        @testset "origin and shift convention" begin
+
+        end
     end
 
 

--- a/test/BaseMesh.jl
+++ b/test/BaseMesh.jl
@@ -70,6 +70,27 @@
         end
 
         @testset "origin and shift convention" begin
+            DIM = 2
+            lattice = Matrix([1.0 0; 0 1]')
+            br = BaseMesh.Brillouin(lattice=lattice)
+
+            # even numbers
+            size = (4, 4)
+            # Gamma-centered, no shift
+            bzmesh = BaseMesh.UniformBZMesh(br=br, size=size, origin=0, shift=0)
+            @test bzmesh[1, 1] ≈ BaseMesh.SVector{DIM,eltype(lattice)}([0.0, 0.0])
+            # M-P, no shift
+            bzmesh = BaseMesh.UniformBZMesh(br=br, size=size, origin=-1 / 2, shift=0)
+            @test bzmesh[3, 3] ≈ BaseMesh.SVector{DIM,eltype(lattice)}([0.0, 0.0])
+
+            # odd numbers
+            size = (5, 5)
+            # Gamma-centered, no shift
+            bzmesh = BaseMesh.UniformBZMesh(br=br, size=size, origin=0, shift=0)
+            @test bzmesh[1, 1] ≈ BaseMesh.SVector{DIM,eltype(lattice)}([0.0, 0.0])
+            # M-P, 1/2 shift
+            bzmesh = BaseMesh.UniformBZMesh(br=br, size=size, origin=-1 / 2, shift=1 // 2)
+            @test bzmesh[3, 3] ≈ BaseMesh.SVector{DIM,eltype(lattice)}([0.0, 0.0])
 
         end
     end

--- a/test/BaseMesh.jl
+++ b/test/BaseMesh.jl
@@ -63,10 +63,10 @@
                 inds = BaseMesh._ind2inds(bzmesh.size, pi)
                 @test bzmesh[inds...] ≈ p # cartesian index
 
-                @test BaseMesh.locate(bzmesh, p) == pi
-                vol += BaseMesh.volume(bzmesh, pi)
+                @test AbstractMeshes.locate(bzmesh, p) == pi
+                vol += AbstractMeshes.volume(bzmesh, pi)
             end
-            @test vol ≈ BaseMesh.volume(bzmesh)
+            @test vol ≈ AbstractMeshes.volume(bzmesh)
         end
 
         @testset "origin and shift convention" begin

--- a/test/BaseMesh.jl
+++ b/test/BaseMesh.jl
@@ -32,7 +32,7 @@
         @testset "Indexing" begin
             size = (3, 4, 5)
             for i in 1:prod(size)
-                @test i == BaseMesh._inds2ind(size, BaseMesh._ind2inds(size, i))
+                @test i == BZMeshes._inds2ind(size, BZMeshes._ind2inds(size, i))
             end
         end
 
@@ -40,27 +40,27 @@
             N1, N2 = 3, 5
             lattice = Matrix([1/N1/2 0; 0 1.0/N2/2]') .* 2π
             # so that bzmesh[i,j] = (2i-1,2j-1)
-            br = BaseMesh.Brillouin(lattice=lattice)
-            bzmesh = BaseMesh.UniformBZMesh(br=br, size=(N1, N2), origin=0)
+            br = BZMeshes.Brillouin(lattice=lattice)
+            bzmesh = BZMeshes.UniformBZMesh(br=br, size=(N1, N2), origin=0)
             for (pi, p) in enumerate(bzmesh)
                 @test bzmesh[pi] ≈ p # linear index
-                inds = BaseMesh._ind2inds(bzmesh.size, pi)
+                inds = BZMeshes._ind2inds(size(bzmesh), pi)
                 @test p ≈ inds .* 2.0 .- 1.0
                 @test bzmesh[inds...] ≈ p # cartesian index
             end
         end
 
         @testset "locate and volume" begin
-            size = (3, 5, 7)
+            msize = (3, 5, 7)
             lattice = Matrix([2.0 0 0; 1 sqrt(3) 0; 7 11 19]')
             # size = (3, 5)
             # lattice = Matrix([2.3 0; 0 7.0]')
-            br = BaseMesh.Brillouin(lattice=lattice)
-            bzmesh = BaseMesh.UniformBZMesh(br=br, size=size)
+            br = BZMeshes.Brillouin(lattice=lattice)
+            bzmesh = BZMeshes.UniformBZMesh(br=br, size=msize)
             vol = 0.0
             for (pi, p) in enumerate(bzmesh)
                 @test bzmesh[pi] ≈ p # linear index
-                inds = BaseMesh._ind2inds(bzmesh.size, pi)
+                inds = BZMeshes._ind2inds(size(bzmesh), pi)
                 @test bzmesh[inds...] ≈ p # cartesian index
 
                 @test AbstractMeshes.locate(bzmesh, p) == pi
@@ -72,25 +72,25 @@
         @testset "origin and shift convention" begin
             DIM = 2
             lattice = Matrix([1.0 0; 0 1]')
-            br = BaseMesh.Brillouin(lattice=lattice)
+            br = BZMeshes.Brillouin(lattice=lattice)
 
             # even numbers
             size = (4, 4)
             # Gamma-centered, no shift
-            bzmesh = BaseMesh.UniformBZMesh(br=br, size=size, origin=0, shift=0)
-            @test bzmesh[1, 1] ≈ BaseMesh.SVector{DIM,eltype(lattice)}([0.0, 0.0])
+            bzmesh = BZMeshes.UniformBZMesh(br=br, size=size, origin=0, shift=0)
+            @test bzmesh[1, 1] ≈ BZMeshes.SVector{DIM,eltype(lattice)}([0.0, 0.0])
             # M-P, no shift
-            bzmesh = BaseMesh.UniformBZMesh(br=br, size=size, origin=-1 / 2, shift=0)
-            @test bzmesh[3, 3] ≈ BaseMesh.SVector{DIM,eltype(lattice)}([0.0, 0.0])
+            bzmesh = BZMeshes.UniformBZMesh(br=br, size=size, origin=-1 / 2, shift=0)
+            @test bzmesh[3, 3] ≈ BZMeshes.SVector{DIM,eltype(lattice)}([0.0, 0.0])
 
             # odd numbers
             size = (5, 5)
             # Gamma-centered, no shift
-            bzmesh = BaseMesh.UniformBZMesh(br=br, size=size, origin=0, shift=0)
-            @test bzmesh[1, 1] ≈ BaseMesh.SVector{DIM,eltype(lattice)}([0.0, 0.0])
+            bzmesh = BZMeshes.UniformBZMesh(br=br, size=size, origin=0, shift=0)
+            @test bzmesh[1, 1] ≈ BZMeshes.SVector{DIM,eltype(lattice)}([0.0, 0.0])
             # M-P, 1/2 shift
-            bzmesh = BaseMesh.UniformBZMesh(br=br, size=size, origin=-1 / 2, shift=1 // 2)
-            @test bzmesh[3, 3] ≈ BaseMesh.SVector{DIM,eltype(lattice)}([0.0, 0.0])
+            bzmesh = BZMeshes.UniformBZMesh(br=br, size=size, origin=-1 / 2, shift=1 // 2)
+            @test bzmesh[3, 3] ≈ BZMeshes.SVector{DIM,eltype(lattice)}([0.0, 0.0])
 
         end
     end

--- a/test/BaseMesh.jl
+++ b/test/BaseMesh.jl
@@ -41,7 +41,7 @@
             lattice = Matrix([1/N1/2 0; 0 1.0/N2/2]') .* 2π
             # so that bzmesh[i,j] = (2i-1,2j-1)
             br = BaseMesh.Brillouin(lattice=lattice)
-            bzmesh = BaseMesh.UniformBZMesh(br=br, size=(N1, N2))
+            bzmesh = BaseMesh.UniformBZMesh(br=br, size=(N1, N2), origin=0)
             for (pi, p) in enumerate(bzmesh)
                 @test bzmesh[pi] ≈ p # linear index
                 inds = BaseMesh._ind2inds(bzmesh.size, pi)

--- a/test/mc.jl
+++ b/test/mc.jl
@@ -2,7 +2,7 @@
     # testing locate and volume functions provided for monte carlo
     rng = MersenneTwister(1234)
 
-    locate, volume = BaseMesh.locate, BaseMesh.volume
+    locate, volume = AbstractMeshes.locate, AbstractMeshes.volume
 
     function test_mc_histogram(mesh::AbstractMesh{T,DIM};
         Npp=1e5, f=(x -> sum(x))) where {T,DIM}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,6 @@ using Test
 
 @testset "BrillouinZoneMeshes.jl" begin
 
-
     if isempty(ARGS)
         # include("barycheb.jl")
         include("BaseMesh.jl")


### PR DESCRIPTION
Re-organized files and modules:
AbstractMesh is now defined in a standalone module, with required interface defined.
Uniform mesh realized as UMesh in BaseMesh with no Brillouin info inside.
Meshes with Brillouin info is realized as a wrapper of mesh from BaseMesh with br::Brillouin, in BZMeshes.